### PR TITLE
Create helpers.py and create attachments_as_bytes method argument

### DIFF
--- a/pysignalclirestapi/api.py
+++ b/pysignalclirestapi/api.py
@@ -127,7 +127,7 @@ class SignalCliRestApi(object):
                 raise exc
             raise_from(SignalCliRestApiError("Couldn't update profile: "), exc)
 
-    def send_message(self, message, recipients, filenames=None):
+    def send_message(self, message, recipients, filenames=None, attachments_as_bytes=None):
         """Send a message to one (or more) recipients.
          
         Additionally files can be attached.
@@ -152,7 +152,12 @@ class SignalCliRestApi(object):
 
         try:
             if "v2" in api_versions:
-                base64_attachments = []
+                if attachments_as_bytes is None:
+                    base64_attachments = []
+                else:
+                    base64_attachments = [
+                        bytes_to_base64(attachment) for attachment in attachments_as_bytes
+                    ]
                 if filenames is not None: 
                     for filename in filenames:
                         with open(filename, "rb") as ofile:

--- a/pysignalclirestapi/api.py
+++ b/pysignalclirestapi/api.py
@@ -5,6 +5,7 @@ import base64
 import json
 from future.utils import raise_from
 import requests
+from .helpers import bytes_to_base64
 
 class SignalCliRestApiError(Exception):
     """SignalCliRestApiError base classi."""
@@ -112,12 +113,7 @@ class SignalCliRestApi(object):
 
             if filename is not None:
                 with open(filename, "rb") as ofile:
-                    base64_avatar = None
-                    if sys.version_info >= (3, 0):
-                        base64_avatar = str(base64.b64encode(ofile.read()), encoding="utf-8")
-                    else:
-                        base64_avatar = str(base64.b64encode(ofile.read())).encode("utf-8")
-
+                    base64_avatar = bytes_to_base64(ofile.read())
                     data["base64_avatar"] = base64_avatar
 
             resp = requests.put(url, json=data)
@@ -160,21 +156,13 @@ class SignalCliRestApi(object):
                 if filenames is not None: 
                     for filename in filenames:
                         with open(filename, "rb") as ofile:
-                            base64_attachment = None 
-                            if sys.version_info >= (3, 0):
-                                base64_attachment = str(base64.b64encode(ofile.read()), encoding="utf-8")
-                            else:
-                                base64_attachment = str(base64.b64encode(ofile.read())).encode("utf-8")
+                            base64_attachment = bytes_to_base64(ofile.read())
                             base64_attachments.append(base64_attachment)
                 data["base64_attachments"] = base64_attachments
             else: # fall back to api version 1 to stay downwards compatible
                 if filenames is not None and len(filenames) == 1:
                     with open(filenames[0], "rb") as ofile:
-                        base64_attachment = None 
-                        if sys.version_info >= (3, 0):
-                            base64_attachment = str(base64.b64encode(ofile.read()), encoding="utf-8")
-                        else:
-                            base64_attachment = str(base64.b64encode(ofile.read())).encode("utf-8")
+                        base64_attachment = bytes_to_base64(ofile.read())
                         data["base64_attachment"] = base64_attachment
             
             resp = requests.post(url, json=data)

--- a/pysignalclirestapi/helpers.py
+++ b/pysignalclirestapi/helpers.py
@@ -1,0 +1,12 @@
+"""Helper functions"""
+
+import base64
+from sys import version_info
+
+def bytes_to_base64(in_bytes: bytes) -> str:
+    """Converts bytes to base64-encoded str using the appropriate system version.
+    """
+    if version_info >= (3, 0):
+        return str(base64.b64encode(in_bytes), encoding="utf-8")
+    else:
+        return str(base64.b64encode(in_bytes)).encode("utf-8")


### PR DESCRIPTION
As discussed in #2, this PR does two things:

1. create helpers.py and use bytes_to_base64() (f413da7)
2. create attachments_as_bytes as method argument (cd7aa04)

In the future, we could also consider offering an ```attachment_as_bytes``` argument in ```update_profile()```.

Although these are just small changes, I'm looking forward to hearing your feedback.

All the best from Germany