### PR TITLE
Add basic auth support to api.py

### DIFF
--- a/pysignalclirestapi/__init__.py
+++ b/pysignalclirestapi/__init__.py
@@ -1,1 +1,1 @@
-from pysignalclirestapi.api import SignalCliRestApi, SignalCliRestApiError
+from pysignalclirestapi.api import SignalCliRestApi, SignalCliRestApiError, SignalCliRestApiAuth, SignalCliRestApiAuth, SignalCliRestApiHTTPBasicAuth

--- a/pysignalclirestapi/__init__.py
+++ b/pysignalclirestapi/__init__.py
@@ -1,1 +1,1 @@
-from pysignalclirestapi.api import SignalCliRestApi, SignalCliRestApiError, SignalCliRestApiAuth, SignalCliRestApiAuth, SignalCliRestApiHTTPBasicAuth
+from pysignalclirestapi.api import SignalCliRestApi, SignalCliRestApiError, SignalCliRestApiAuth, SignalCliRestApiHTTPBasicAuth

--- a/pysignalclirestapi/api.py
+++ b/pysignalclirestapi/api.py
@@ -9,8 +9,6 @@ from future.utils import raise_from
 import requests
 from .helpers import bytes_to_base64
 
-print('correct module')
-
 
 class SignalCliRestApiError(Exception):
     """SignalCliRestApiError base classi."""

--- a/pysignalclirestapi/api.py
+++ b/pysignalclirestapi/api.py
@@ -19,7 +19,7 @@ class SignalCliRestApiAuth(ABC):
     """SignalCliRestApiAuth base class."""
 
     @abstractmethod
-    def getAuth():
+    def get_auth():
         pass
 
 
@@ -29,7 +29,7 @@ class SignalCliRestApiHTTPBasicAuth(SignalCliRestApiAuth):
     def __init__(self, basic_auth_user, basic_auth_pwd):
         self._auth = HTTPBasicAuth(basic_auth_user, basic_auth_pwd)
 
-    def getAuth(self):
+    def get_auth(self):
         return self._auth
 
 
@@ -44,7 +44,7 @@ class SignalCliRestApi(object):
         if auth:
             assert issubclass(
                 type(auth), SignalCliRestApiAuth), "Expecting a subclass of SignalCliRestApiAuth as auth parameter"
-            self._auth = auth.getAuth()
+            self._auth = auth.get_auth()
         else:
             self._auth = None
 

--- a/pysignalclirestapi/api.py
+++ b/pysignalclirestapi/api.py
@@ -3,26 +3,37 @@
 import sys
 import base64
 import json
+
+from requests.models import HTTPBasicAuth
 from future.utils import raise_from
 import requests
 from .helpers import bytes_to_base64
+
+print('correct module')
+
 
 class SignalCliRestApiError(Exception):
     """SignalCliRestApiError base classi."""
     pass
 
+
 class SignalCliRestApi(object):
     """SignalCliRestApi implementation."""
-    def __init__(self, base_url, number):
+
+    def __init__(self, base_url, number, basic_auth_user, basic_auth_pwd):
         """Initialize the class."""
         super(SignalCliRestApi, self).__init__()
-        
         self._base_url = base_url
         self._number = number
+        if basic_auth_user and basic_auth_pwd:
+            self._basic_auth = HTTPBasicAuth(basic_auth_user, basic_auth_pwd)
+        else:
+            self._basic_auth = None
 
     def api_info(self):
         try:
-            resp = requests.get(self._base_url + "/v1/about")
+            resp = requests.get(
+                self._base_url + "/v1/about", auth=self._basic_auth)
             if resp.status_code == 404:
                 return ["v1", 1]
             data = json.loads(resp.content)
@@ -36,10 +47,12 @@ class SignalCliRestApi(object):
             return api_versions, build_nr
 
         except Exception as exc:
-            raise_from(SignalCliRestApiError("Couldn't determine REST API version"), exc)
+            raise_from(SignalCliRestApiError(
+                "Couldn't determine REST API version"), exc)
 
     def mode(self):
-        resp = requests.get(self._base_url + "/v1/about")
+        resp = requests.get(self._base_url + "/v1/about",
+                            auth=self._basic_auth)
         data = json.loads(resp.content)
 
         mode = "unknown"
@@ -52,56 +65,62 @@ class SignalCliRestApi(object):
     def create_group(self, name, members):
         try:
 
-            url = self._base_url + "/v1/groups/" + self._number 
+            url = self._base_url + "/v1/groups/" + self._number
             data = {
                 "members": members,
                 "name": name
             }
-            resp = requests.post(url, json=data)
+            resp = requests.post(url, json=data, auth=self._basic_auth)
             if resp.status_code != 201 and resp.status_code != 200:
                 json_resp = resp.json()
                 if "error" in json_resp:
                     raise SignalCliRestApiError(json_resp["error"])
-                raise SignalCliRestApiError("Unknown error while creating Signal Messenger group")
+                raise SignalCliRestApiError(
+                    "Unknown error while creating Signal Messenger group")
             return resp.json()["id"]
         except Exception as exc:
             if exc.__class__ == SignalCliRestApiError:
                 raise exc
-            raise_from(SignalCliRestApiError("Couldn't create Signal Messenger group: "), exc)
+            raise_from(SignalCliRestApiError(
+                "Couldn't create Signal Messenger group: "), exc)
 
     def list_groups(self):
         try:
-            url = self._base_url + "/v1/groups/" + self._number 
-            resp = requests.get(url)
+            url = self._base_url + "/v1/groups/" + self._number
+            resp = requests.get(url, auth=self._basic_auth)
             json_resp = resp.json()
-            if resp.status_code != 200: 
+            if resp.status_code != 200:
                 if "error" in json_resp:
                     raise SignalCliRestApiError(json_resp["error"])
-                raise SignalCliRestApiError("Unknown error while listing Signal Messenger groups")
+                raise SignalCliRestApiError(
+                    "Unknown error while listing Signal Messenger groups")
             return json_resp
         except Exception as exc:
             if exc.__class__ == SignalCliRestApiError:
                 raise exc
-            raise_from(SignalCliRestApiError("Couldn't list Signal Messenger groups: "), exc)
+            raise_from(SignalCliRestApiError(
+                "Couldn't list Signal Messenger groups: "), exc)
 
     def receive(self):
         try:
             url = self._base_url + "/v1/receive/" + self._number
-            resp = requests.get(url)
+            resp = requests.get(url, auth=self._basic_auth)
             json_resp = resp.json()
-            if resp.status_code != 200: 
+            if resp.status_code != 200:
                 if "error" in json_resp:
                     raise SignalCliRestApiError(json_resp["error"])
-                raise SignalCliRestApiError("Unknown error while receiving Signal Messenger data")
+                raise SignalCliRestApiError(
+                    "Unknown error while receiving Signal Messenger data")
             return json_resp
         except Exception as exc:
             if exc.__class__ == SignalCliRestApiError:
                 raise exc
-            raise_from(SignalCliRestApiError("Couldn't receive Signal Messenger data: "), exc)
+            raise_from(SignalCliRestApiError(
+                "Couldn't receive Signal Messenger data: "), exc)
 
     def update_profile(self, name, filename=None):
         """Update Profile.
-           
+
         Set the name and optionally an avatar.
         """
 
@@ -116,12 +135,13 @@ class SignalCliRestApi(object):
                     base64_avatar = bytes_to_base64(ofile.read())
                     data["base64_avatar"] = base64_avatar
 
-            resp = requests.put(url, json=data)
+            resp = requests.put(url, json=data, auth=self._basic_auth)
             if resp.status_code != 204:
                 json_resp = resp.json()
                 if "error" in json_resp:
                     raise SignalCliRestApiError(json_resp["error"])
-                raise SignalCliRestApiError("Unknown error while updating profile")
+                raise SignalCliRestApiError(
+                    "Unknown error while updating profile")
         except Exception as exc:
             if exc.__class__ == SignalCliRestApiError:
                 raise exc
@@ -129,23 +149,24 @@ class SignalCliRestApi(object):
 
     def send_message(self, message, recipients, filenames=None, attachments_as_bytes=None):
         """Send a message to one (or more) recipients.
-         
+
         Additionally files can be attached.
         """
-        
+
         api_versions, build_nr = self.api_info()
         if filenames is not None and len(filenames) > 1:
-            if "v2" not in api_versions: # multiple attachments only allowed when api version >= v2
-                raise SignalCliRestApiError("This signal-cli-rest-api version is not capable of sending multiple attachments. Please upgrade your signal-cli-rest-api docker container!")
-        
-        
+            if "v2" not in api_versions:  # multiple attachments only allowed when api version >= v2
+                raise SignalCliRestApiError(
+                    "This signal-cli-rest-api version is not capable of sending multiple attachments. Please upgrade your signal-cli-rest-api docker container!")
+
         url = self._base_url + "/v2/send"
-        if "v2" not in api_versions: # fall back to old api version to stay downwards compatible.
+        # fall back to old api version to stay downwards compatible.
+        if "v2" not in api_versions:
             url = self._base_url + "/v1/send"
 
         data = {
             "message": message,
-            "number": self._number, 
+            "number": self._number,
         }
 
         data["recipients"] = recipients
@@ -158,25 +179,27 @@ class SignalCliRestApi(object):
                     base64_attachments = [
                         bytes_to_base64(attachment) for attachment in attachments_as_bytes
                     ]
-                if filenames is not None: 
+                if filenames is not None:
                     for filename in filenames:
                         with open(filename, "rb") as ofile:
                             base64_attachment = bytes_to_base64(ofile.read())
                             base64_attachments.append(base64_attachment)
                 data["base64_attachments"] = base64_attachments
-            else: # fall back to api version 1 to stay downwards compatible
+            else:  # fall back to api version 1 to stay downwards compatible
                 if filenames is not None and len(filenames) == 1:
                     with open(filenames[0], "rb") as ofile:
                         base64_attachment = bytes_to_base64(ofile.read())
                         data["base64_attachment"] = base64_attachment
-            
-            resp = requests.post(url, json=data)
+
+            resp = requests.post(url, json=data, auth=self._basic_auth)
             if resp.status_code != 201:
                 json_resp = resp.json()
                 if "error" in json_resp:
                     raise SignalCliRestApiError(json_resp["error"])
-                raise SignalCliRestApiError("Unknown error while sending signal message")
+                raise SignalCliRestApiError(
+                    "Unknown error while sending signal message")
         except Exception as exc:
             if exc.__class__ == SignalCliRestApiError:
                 raise exc
-            raise_from(SignalCliRestApiError("Couldn't send signal message"), exc)
+            raise_from(SignalCliRestApiError(
+                "Couldn't send signal message"), exc)


### PR DESCRIPTION
Hi Bernhard, I use your Signal CLI service container (tnx, btw!) and put it behind a nginx with an basic auth protection. Now I adapted your python client API. It's a rather superficial adaption (just manual tests) - maybe you'll have a look at it yourself. And I am not that proficient with python..

One more note: my change always adds a `basic_auth` parameter to `requests` call. Without basic auth parameters it defaults to `None`. This matches the [current `requests` API](https://docs.python-requests.org/en/latest/api/#requests.Request). 

It would be of great help if you push the update to pypi.

Best!
Mathias